### PR TITLE
Handle errors when TRACES is not available

### DIFF
--- a/server/utils/soap-traces.js
+++ b/server/utils/soap-traces.js
@@ -247,6 +247,12 @@ export async function submitDDS(commodities, geolocationVisible, user) {
       },
     },
   );
+  if (submitResponse.status >= 500) {
+    return {
+      identifier: undefined,
+      error: 'TRACES database currently unavailable, try again later',
+    };
+  }
   const submitResponseXML = await submitResponse.text();
   const xml = new DOMParser().parseFromString(submitResponseXML, 'text/xml');
 


### PR DESCRIPTION
This pull request adds error handling to deal with the case where the TRACES database is unavailable.

When retrieving DDS info, the status is set to UNKNOWN. When submitting a DDS, the user gets an error message that the TRACES database is currently unavailable.