### PR TITLE
Fix handling of quantities, simplify commodities data structures

### DIFF
--- a/components/PlacesForm.vue
+++ b/components/PlacesForm.vue
@@ -45,7 +45,7 @@ watch(area, (value) => {
         <v-col :cols="mdAndUp ? 2 : xs ? 4 : 3">
           <v-sheet
             >{{ geojson.features.length }} Ort{{ geojson.features.length === 1 ? '' : 'e' }}<br />{{
-              area
+              area.toLocaleString('de-AT')
             }}
             ha</v-sheet
           >

--- a/components/StatementList.vue
+++ b/components/StatementList.vue
@@ -37,23 +37,19 @@ statementCount.value = statements.value?.length || 0;
           Rohstoffe/Erzeugnisse
           <v-table density="compact">
             <tbody>
-              <template v-for="(value, key) in item.statement.commodities" :key="key">
+              <template v-for="value in item.statement.commodities" :key="value.key">
                 <tr v-if="value.geojson.features.length">
                   <td>
                     <v-icon
                       :icon="
-                        COMMODITIES[/** @type {import('~/utils/constants').Commodity} */ (key)]
-                          ?.icon || mdiCardBulletedOutline
+                        COMMODITIES[
+                          /** @type {import('~/utils/constants').Commodity} */ (value.key)
+                        ]?.icon || mdiCardBulletedOutline
                       "
                     />
                   </td>
                   <td>
-                    {{
-                      getCommoditySummary({
-                        key: /** @type {import('~/utils/constants').Commodity} */ (key),
-                        ...value,
-                      })
-                    }}
+                    {{ getCommoditySummary(value) }}
                   </td>
                 </tr>
               </template>

--- a/composables/useStatement.js
+++ b/composables/useStatement.js
@@ -93,7 +93,7 @@ export function useStatement(commodity) {
 
     function createSnapshot() {
       snapshot = {
-        quantity: quantity.value,
+        quantity: structuredClone(toRaw(quantity.value)),
         geojson: structuredClone(geojson.value),
       };
       modifiedSinceSnapshot.value = false;

--- a/server/db/schema/statements.js
+++ b/server/db/schema/statements.js
@@ -3,7 +3,7 @@ import users from './users';
 
 /**
  * @typedef {Object} StatementPayload
- * @property {Object<string, import('~/pages/statement.vue').CommodityData>} commodities
+ * @property {Array<import('~/server/utils/soap-traces').CommodityDataWithKey>} commodities
  * @property {boolean} geolocationVisible
  */
 

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -12,33 +12,30 @@ export function toPrecision(number, precision) {
  * @returns {string}
  */
 export function getCommoditySummary(commodity) {
-  if (!commodity || !commodity.geojson.features.length) {
+  if (!commodity || !unref(commodity.geojson).features.length) {
     return '';
   }
   /** @type {import('~/utils/constants').Commodity} */
   const commodityKey = commodity.key;
-  const places = commodity.geojson.features.length;
+  const places = unref(commodity.geojson).features.length;
   const hsHeadings = COMMODITIES[commodityKey].hsHeadings
-    .filter((key) => commodity.quantity[key])
+    .filter((hsHeading) => unref(commodity.quantity)[hsHeading])
     .map(
-      (key) =>
-        `${commodity.quantity[key]?.toLocaleString('de-AT')} ${COMMODITIES[commodityKey].units} ${HS_HEADING[key] || key}`,
+      (hsHeading) =>
+        `${unref(commodity.quantity)[hsHeading]?.toLocaleString('de-AT')} ${COMMODITIES[commodityKey].units} ${HS_HEADING[hsHeading] || hsHeading}`,
     );
   return `${places} Ort${places === 1 ? '' : 'e'}, ${hsHeadings.join(', ')}`;
 }
 
 /**
- * @param {Object<string, import('~/pages/statement.vue').CommodityData>} commodities
+ * @param {Array<import('~/pages/statement.vue').CommodityDataWithKey>} commodities
  * @returns {string}
  */
 export function getCommoditiesSummary(commodities) {
   return commodities
-    ? `\nRohstoffe/Erzeugnisse:\n${Object.entries(commodities)
-        .filter(([, value]) => value.geojson.features.length)
-        .map(
-          ([key, value]) =>
-            `${getCommoditySummary({ key: /** @type {import('~/utils/constants').Commodity} */ (key), ...value })}`,
-        )
+    ? `\nRohstoffe/Erzeugnisse:\n${commodities
+        .filter((commodity) => unref(commodity.geojson).features.length)
+        .map((commodity) => `${getCommoditySummary(commodity)}`)
         .join('\n')}`
     : '';
 }


### PR DESCRIPTION
Make sure quantities are restored upon snapshot undo, and use commodities with keys throughout as well as unref() for quantities and geojson to avoid on-the-fly creation of derived data structures.