### PR TITLE
Get rid of vue warnings and fix color mode

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -15,7 +15,7 @@ export default defineNuxtConfig({
     'nuxt-auth-utils',
     'vuetify-nuxt-module',
     'nuxt-nodemailer',
-    '@nuxtjs/color-mode',
+    '@eschricht/nuxt-color-mode',
   ],
   runtimeConfig: {
     // See server/utils/database.js and server/plugins/storage.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,10 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
+        "@eschricht/nuxt-color-mode": "^1.2.0",
         "@mdi/js": "^7.4.47",
         "@nuxt/eslint": "^1.7.1",
         "@nuxt/fonts": "^0.11.0",
-        "@nuxtjs/color-mode": "^3.5.2",
         "@w3geo/vue-place-search": "^2.0.0",
         "@xmldom/xmldom": "^0.9.8",
         "db0": "^0.3.2",
@@ -27,8 +27,8 @@
         "pmtiles-protocol": "^1.0.5",
         "polygon-clipping": "^0.15.7",
         "uqr": "^0.1.2",
-        "vue": "*",
-        "vue-router": "*",
+        "vue": "latest",
+        "vue-router": "latest",
         "vuetify-nuxt-module": "^0.18.6"
       },
       "devDependencies": {
@@ -1513,6 +1513,47 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eschricht/nuxt-color-mode": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eschricht/nuxt-color-mode/-/nuxt-color-mode-1.2.0.tgz",
+      "integrity": "sha512-t4ooU16Gox3F98kK+mQYlTfPXeJhaMH9QkDrHRa5j4HSSnicuHHKdBHn9UasbQF0A4pwQZg04lyLSEbTMK7kBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^4.0.0"
+      }
+    },
+    "node_modules/@eschricht/nuxt-color-mode/node_modules/@nuxt/kit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.0.2.tgz",
+      "integrity": "sha512-OtLkVYHpfrm1FzGSGxl0H3QXLgO41yxOgni5S6zzLG4gblG71Fy82B2QTdqJLzTLKWObiILKDhrysBtmDkp3LA==",
+      "license": "MIT",
+      "dependencies": {
+        "c12": "^3.1.0",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "errx": "^0.1.0",
+        "exsolve": "^1.0.7",
+        "ignore": "^7.0.5",
+        "jiti": "^2.5.1",
+        "klona": "^2.0.6",
+        "mlly": "^1.7.4",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.2.0",
+        "scule": "^1.3.0",
+        "semver": "^7.7.2",
+        "std-env": "^3.9.0",
+        "tinyglobby": "^0.2.14",
+        "ufo": "^1.6.1",
+        "unctx": "^2.4.1",
+        "unimport": "^5.2.0",
+        "untyped": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
@@ -2676,47 +2717,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@nuxtjs/color-mode": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/color-mode/-/color-mode-3.5.2.tgz",
-      "integrity": "sha512-cC6RfgZh3guHBMLLjrBB2Uti5eUoGM9KyauOaYS9ETmxNWBMTvpgjvSiSJp1OFljIXPIqVTJ3xtJpSNZiO3ZaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@nuxt/kit": "^3.13.2",
-        "pathe": "^1.1.2",
-        "pkg-types": "^1.2.1",
-        "semver": "^7.6.3"
-      }
-    },
-    "node_modules/@nuxtjs/color-mode/node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT"
-    },
-    "node_modules/@nuxtjs/color-mode/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "license": "MIT"
-    },
-    "node_modules/@nuxtjs/color-mode/node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/@nuxtjs/color-mode/node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "license": "MIT"
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
       "version": "0.75.1",
@@ -9567,9 +9567,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "node": "22.x"
   },
   "dependencies": {
+    "@eschricht/nuxt-color-mode": "^1.2.0",
     "@mdi/js": "^7.4.47",
     "@nuxt/eslint": "^1.7.1",
     "@nuxt/fonts": "^0.11.0",
-    "@nuxtjs/color-mode": "^3.5.2",
     "@w3geo/vue-place-search": "^2.0.0",
     "@xmldom/xmldom": "^0.9.8",
     "db0": "^0.3.2",

--- a/pages/statement.vue
+++ b/pages/statement.vue
@@ -316,7 +316,6 @@ async function submit() {
             </v-card-text>
             <v-card-actions>
               <v-btn
-                v-card-actions
                 text="E-Mail"
                 :prepend-icon="mdiEmailFastOutline"
                 color="primary"


### PR DESCRIPTION
This pull request fixes vue warnings in the console, and by replacing the color-mode plugin with one that uses the sec-ch-prefers-color-scheme header, also fixes the initial color mode of the app.