### PR TITLE
Fix Rohholz submission after TRACES changes

### DIFF
--- a/components/PlacesForm.vue
+++ b/components/PlacesForm.vue
@@ -24,7 +24,7 @@ for (const hsCode of commodityData.hsHeadings) {
 
 watch(area, (value) => {
   if (factor) {
-    quantity.value[commodityData.hsHeadings[0]] = toPrecision(value * factor, 2);
+    quantity.value[commodityData.hsHeadings[0]] = toPrecision(value * factor, 0);
   }
 });
 </script>


### PR DESCRIPTION
This pull request fixes the submission of the Rohholz commodity, where the allowed quantity units have changed in the TRACES checks.

It also adds more information to TRACES error messages, and makes it so a statement is not deleted when a TRACES error occurs.