### PR TITLE
Fix commodity card bugs

### DIFF
--- a/app/components/StatementList.vue
+++ b/app/components/StatementList.vue
@@ -18,16 +18,19 @@ const { data: userData } = await useFetch('/api/users/me');
 statementCount.value = statements.value?.length || 0;
 
 const autoRefreshStatements = statements.value?.filter((s) => !s.referenceNumber);
-if (autoRefreshStatements && autoRefreshStatements.length > 0) {
-  const interval = setInterval(async () => {
-    for (const s of autoRefreshStatements) {
-      await toggleFullStatement(s.ddsId);
-    }
-    if (statements.value?.every((s) => s.referenceNumber)) {
-      clearInterval(interval);
-    }
-  }, 30000);
-}
+
+onNuxtReady(() => {
+  if (autoRefreshStatements && autoRefreshStatements.length > 0) {
+    const interval = setInterval(async () => {
+      for (const s of autoRefreshStatements) {
+        await toggleFullStatement(s.ddsId);
+      }
+      if (statements.value?.every((s) => s.referenceNumber)) {
+        clearInterval(interval);
+      }
+    }, 30000);
+  }
+});
 
 /**
  * @param {string} ddsId

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -21,7 +21,7 @@ export function getCommoditySummary(commodity) {
       (hsHeading) =>
         `${unref(commodity.quantity)[hsHeading]?.toLocaleString('de-AT')} ${COMMODITIES[commodityKey].units} ${HS_HEADING[hsHeading] || hsHeading}`,
     );
-  return places
+  return hsHeadings.length
     ? `${hsHeadings.join(', ')}, ${places ? `${places} Ort${places === 1 ? '' : 'e'}` : 'Ort nicht geteilt'}`
     : '';
 }


### PR DESCRIPTION
This pull request fixes two bugs related to the list of commodity cards:

* Display commodities when location is not shared
* Do not refresh reference numbers with `setTimeout()` when rendering server side