### PR TITLE
Store less data

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,13 +1,11 @@
 <script setup>
 import { mdiAccountCircle } from '@mdi/js';
-import DisclaimerDialog from './components/DisclaimerDialog.vue';
 
 useHead({
   titleTemplate: (titleChunk) => (titleChunk ? `${titleChunk} | EUDR Meldung` : 'EUDR Meldung'),
 });
 const theme = useColorMode();
 const { mdAndUp } = useDisplay();
-const { user } = useUserSession();
 const drawer = ref(false);
 const router = useRouter();
 const routes = router.getRoutes();
@@ -35,13 +33,7 @@ const items = routes
               EUDR Meldung
             </NuxtLink>
           </v-app-bar-title>
-          <v-btn
-            variant="plain"
-            to="/account"
-            :icon="!user?.login ? mdiAccountCircle : undefined"
-            :append-icon="user?.login ? mdiAccountCircle : undefined"
-            :text="user?.login"
-          />
+          <v-btn variant="plain" to="/account" :icon="mdiAccountCircle" />
         </v-toolbar>
       </template>
     </v-app-bar>

--- a/app/pages/account.vue
+++ b/app/pages/account.vue
@@ -31,7 +31,7 @@ async function submitOtp() {
 }
 
 /** @type {import('vue').Ref<import('~/components/UserData.vue').default|null>} */
-const userData = ref(null);
+const userDataForm = ref(null);
 
 const loginRetry = useCookie('login-retry');
 const loginError = useCookie('login-error');
@@ -58,12 +58,12 @@ const loginError = useCookie('login-error');
         <v-card v-if="loggedIn">
           <v-card-title>Angaben zum Betrieb</v-card-title>
           <v-card-text>
-            <UserData ref="userData" verbose />
+            <UserData ref="userDataForm" verbose />
           </v-card-text>
-          <v-card-actions>
+          <v-card-actions v-if="userDataForm?.canSave">
             <v-btn
               color="primary"
-              @click="async () => (await userData?.validate()) && userData?.save()"
+              @click="async () => (await userDataForm?.validate()) && userDataForm?.save()"
             >
               Speichern
             </v-btn>

--- a/app/pages/privacy-statement.vue
+++ b/app/pages/privacy-statement.vue
@@ -25,39 +25,49 @@ useSeoMeta({
               <a href="mailto:service.entwaldung@bmluk.gv.at">service.entwaldung@bmluk.gv.at</a>.
             </div>
             <div class="text-body-1 mb-2">
-              Auf der Seite "Mein Konto" unter "Angaben zum Betrieb", werden die von Ihnen
-              eingegebenen persönlichen Daten, nämlich bei Verwendung der Login-Methode "E-Mail"
-              Name, Adresse, e-mail Adresse und Identifikationsnummer (GLN, UID oder Steuernummer),
-              alternativ dazu bei Verwendung der Login-Methode "eAMA" die LFBIS-Nummer des
-              Betriebes, und alternativ dazu bei Verwendung der Login-Methode "ID Austria" die
-              Identifikationsnummer (GLN, UID oder Steuernummer), zum Zweck der Erstellung von
-              Sorgfaltserklärungen gespeichert.
+              Vom BMLUK werden im Rahmen der Nutzung dieser Applikation keine personenbezogenen
+              Daten gespeichert.
             </div>
             <div class="text-body-1 mb-2">
-              Nach Erstellung einer Sorgfaltserklärung wird die von der TRACES Datenbank der EU
-              Kommission bereitgestellte ID der Sorgfaltserklärung zum Zweck der Zurodnung derselben
-              zu Ihrem Benutzerkonto gespeichert.
+              Ausnahmen:
+              <ul class="pl-4 mt-2">
+                <li class="mb-1">
+                  Auf der Seite "Mein Konto" unter "Angaben zum Betrieb", werden die von Ihnen
+                  eingegebenen personenbezogenen Daten, nämlich bei Verwendung der Login-Methode "ID
+                  Austria" die Identifikationsnummer (GLN, UID oder Steuernummer)bei Verwendung der
+                  Login-Methode "E-Mail" zusätzlich Name, Adresse, und e-mail Adresse, zum Zweck der
+                  Erstellung von Sorgfaltserklärungen gespeichert.
+                </li>
+                <li class="mb-1">
+                  Sofern Sie für jemand anderen eine Sorgfaltserklärung erstellen, speichern wir
+                  Namen und Adresse Ihres Betriebes, um Sie als Ersteller der Sorgfaltserklärung
+                  zuordnen zu können.
+                </li>
+                <li class="mb-1">
+                  Sofern Sie von jemand anderem eine Sorgfaltserklärung erstellen lassen, speichern
+                  wir die interne ID der Sorgfaltserklärung, die von der TRACES Datenbank der
+                  EU-Kommission vergeben wird, damit wir die Sorgfaltserklärung dem Konto des
+                  Erstellers zuordnen können.
+                </li>
+              </ul>
             </div>
             <div class="text-body-1 mb-2">
-              Sie können jederzeit durch formlose Mitteilung mit Angabe Ihrer Benutzer-ID (siehe
-              rechts oben in der grünen Titelleiste) an
+              Wenn Sie von einer der oben genannten Ausnahmen betroffen sind, können Sie jederzeit
+              durch formlose Mitteilung an
               <a href="mailto:service.entwaldung@bmluk.gv.at">service.entwaldung@bmluk.gv.at</a>
-              die Löschung Ihres Benutzerkontos beantragen, womit sämtliche vom BMLUK gespeicherten
-              Daten gelöscht werden. Aus technischen Gründen ist danach über die Applikation kein
-              Zugriff auf die Referenz- und Verifikationsnummern der mit der Applikation erstellten
-              Sorgfaltserklärungen mehr möglich. Sollten Sie später wieder Zugriff auf diese
-              Referenz- und Verifikationsnummern benötigen, müssen Sie sich erneut mit der gleichen
-              Login-Methode und dem gleichen Benutzer anmelden.
+              die Löschung Ihrer vom BMLUK gespeicherten Daten beantragen.
             </div>
             <div class="text-body-1 mb-2">
-              Bei Klicken der Schaltfläche "Übermitteln" auf der Seite "Sorgfaltserklärung" werden
-              Ihre Benutzer-ID als interne Referenz (LFBIS-Nummer bei eAMA Login, bPK bei ID Austria
-              Login, e-mail Adresse bei E-Mail Login), Name und Adresse des Betriebes, die
-              Identifikationsnummer, sowie die für die Sorgfaltserklärung erfassten Flächen- bzw.
-              Punktdaten, Erzeugnisse, und deren Mengen an die TRACES Datenbank der EU-Kommission
-              übermittelt. Die dortige Verarbeitung dieser Daten liegt außerhalb des
-              Verantworungsbereiches des BMLUK. Die Datenschutzerklärung der EU-Kommission für die
-              TRACES Datenbank ist unter
+              Bei Klicken der Schaltfläche "Bestätigen und Übermitteln" auf der Seite
+              "Sorgfaltserklärung" wird Ihre Benutzer-ID (LFBIS-Nummer bei eAMA Login, bPK bei ID
+              Austria Login, e-mail Adresse bei E-Mail Login) als interne Referenz an die
+              TRACES-Datenbank der EU übermittelt, damit Sie bei Nutzung dieser Applikation die
+              Zugriff auf Ihre Sorgfaltserklärungen haben. Weiters werden Name und Adresse des
+              Betriebes, die Identifikationsnummer, sowie die für die Sorgfaltserklärung erfassten
+              Flächen- bzw. Punktdaten, Erzeugnisse, und deren Mengen an die TRACES Datenbank der
+              EU-Kommission übermittelt, da diese Angaben für die Sorgfaltserklärung verpflichtend
+              sind. Die Verarbeitung dieser Daten liegt außerhalb des Verantworungsbereiches des
+              BMLUK. Die Datenschutzerklärung der EU-Kommission für die TRACES Datenbank ist unter
               <a
                 href="https://eudr.webcloud.ec.europa.eu/tracesnt/privacy-statement"
                 target="_blank"

--- a/app/pages/statement.vue
+++ b/app/pages/statement.vue
@@ -342,19 +342,29 @@ function cancelSpecies() {
               </template>
             </v-checkbox>
             <div class="text-body-1 mt-4">
-              Hiermit beauftrage ich das Bundesministerium für Land- und Forstwirtschaft, Klima- und
-              Umweltschutz, Regionen und Wasserwirtschaft (BMLUK), für mich als Bevollmächtiger im
-              Sinne von Artikel 2 Ziffer 22 der Verordnung (EU) 2023/1115 aufzutreten und die von
-              mir gestellte Sorgfaltserklärung an das Informationssystem gemäß Artikel 33 dieser
-              Verordnung zu übermitteln. Ich bestätige, dass ich die alleinige Verantwortung für den
-              Inhalt der Sorgfaltserklärung übernehme.
+              Hiermit beauftrag{{ onBehalfOfUser ? 't ' + onBehalfOfUser.name : 'e ich' }} das
+              Bundesministerium für Land- und Forstwirtschaft, Klima- und Umweltschutz, Regionen und
+              Wasserwirtschaft (BMLUK), für {{ onBehalfOfUser ? onBehalfOfUser.name : 'mich' }} als
+              Bevollmächtiger im Sinne von Artikel 2 Ziffer 22 der Verordnung (EU) 2023/1115
+              aufzutreten und die
+              {{ onBehalfOfUser ? 'für ' + onBehalfOfUser.name : 'von mir' }} erstellte
+              Sorgfaltserklärung an das Informationssystem gemäß Artikel 33 dieser Verordnung zu
+              übermitteln.
+              {{ onBehalfOfUser ? onBehalfOfUser.name + ' bestätigt' : 'Ich bestätige' }}, die
+              alleinige Verantwortung für den Inhalt der Sorgfaltserklärung zu übernehmen.
             </div>
             <div class="text-body-1 mt-4">
-              Durch Übermittlung dieser Sorgfaltserklärung bestätige ich, dass ich die
-              Sorgfaltspflicht gemäß der Verordnung (EU) 2023/1115 durchgeführt habe, und dass kein
-              oder lediglich ein vernachlässigbares Risiko dahingehend festgestellt wurde, dass die
-              relevanten Erzeugnisse gegen Artikel 3 Buchstaben a oder b dieser Verordnung
-              verstoßen.
+              Durch Übermittlung dieser Sorgfaltserklärung bestätig{{
+                onBehalfOfUser ? 't ' + onBehalfOfUser.name : 'e ich'
+              }}, die Sorgfaltspflicht gemäß der Verordnung (EU) 2023/1115 durchgeführt zu haben,
+              und dass kein oder lediglich ein vernachlässigbares Risiko dahingehend festgestellt
+              wurde, dass die relevanten Erzeugnisse gegen Artikel 3 Buchstaben a oder b dieser
+              Verordnung verstoßen.
+            </div>
+            <div v-if="onBehalfOfUser" class="text-body-1 mt-4">
+              Ich nehme zur Kenntnis, dass Name und Adresse meines Betriebes gespeichert werden, um
+              mich als Ersteller dieser Sorgfaltserklärung für {{ onBehalfOfUser.name }} zuordnen zu
+              können.
             </div>
           </v-card-text>
           <v-card-actions v-if="canSend">
@@ -374,13 +384,18 @@ function cancelSpecies() {
           <v-card>
             <v-card-title>Jemand anders beauftragen</v-card-title>
             <v-card-text>
-              Sie können jetzt einen Link zur Erstellung einer Sorgfaltserklärung verschicken.
-              <b>Bitte beachten Sie:</b> Nur Personen, die über ein eAMA oder ID Austria Login
-              verfügen, können Sorgfaltserklärungen erstellen.<br /><br />
-              Mit der Weitergabe des Links per E-Mail, SMS oder QR-Code erklärt sich der
-              Marktteilnehmer damit einverstanden, dass die Sorgfaltserklärung zwar von einer
-              anderen Person erstellt wird, die Verantwortung für die Richtigkeit der Angaben aber
-              weiterhin beim Marktteilnehmer liegt.
+              <div class="text-body-1 mb-2">
+                Sie können jetzt einen Link zur Erstellung einer Sorgfaltserklärung verschicken.
+                <b>Bitte beachten Sie:</b> Nur Personen, die über ein eAMA oder ID Austria Login
+                verfügen, können Sorgfaltserklärungen erstellen.
+              </div>
+              <div class="text-body-1 mb-2">
+                Mit der Weitergabe des Links per E-Mail, SMS oder QR-Code nehme ich zur Kenntnis,
+                dass die volle Verantwortung für die Richtigkeit der Angaben einer von einer anderen
+                Person für mich erstellten Sorgfaltserklärung bei mir liegt. Weiters nehme ich zur
+                Kenntnis, dass die interne TRACES Datenbank ID der Sorgfaltserklärung gespeichert
+                wird, um diese dem Ersteller zuordnen zu können.
+              </div>
             </v-card-text>
             <v-card-actions>
               <v-btn

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -1,25 +1,18 @@
 /**
+ * @typedef {Object} EditableUserData
+ * @property {string} name
+ * @property {string} address
+ * @property {'GLN'|'TIN'|'VAT'} identifierType
+ * @property {string} identifierValue
+ */
+
+/**
  * @param {number} number
  * @param {number} precision
  * @returns {number}
  */
 export function toPrecision(number, precision) {
   return Math.round(number * 10 ** precision) / 10 ** precision;
-}
-
-/**
- * @param {import('vue').Ref<import('~~/server/db/schema/users').User|undefined|null>} userData
- * @returns {Promise<void>}
- */
-export async function saveUserData(userData) {
-  const body = userData.value;
-  if (!body) {
-    return;
-  }
-  await $fetch('/api/users/me', {
-    method: 'PUT',
-    body,
-  });
 }
 
 /**

--- a/server/api/ama/login.post.js
+++ b/server/api/ama/login.post.js
@@ -1,5 +1,4 @@
 import { request } from 'https';
-import users from '~~/server/db/schema/users';
 
 export default defineEventHandler(async (event) => {
   try {
@@ -60,28 +59,12 @@ export default defineEventHandler(async (event) => {
       req.end();
     });
 
-    await useDb()
-      .insert(users)
-      .values({
-        id: user.betriebsnummern,
-        emailVerified: false,
-        loginProvider: 'AMA',
-      })
-      //TODO remove - this only deletes legacy data
-      .onConflictDoUpdate({
-        target: users.id,
-        set: {
-          name: null,
-          address: null,
-          identifierType: null,
-          identifierValue: null,
-        },
-      });
     await setUserSession(event, {
       user: {
         login: user.betriebsnummern,
       },
       loggedInAt: Date.now(),
+      loginProvider: 'AMA',
       secure: {
         name: user.bewname,
         address: user.bewadr,

--- a/server/api/auth/email.js
+++ b/server/api/auth/email.js
@@ -32,7 +32,6 @@ export default defineEventHandler(async (event) => {
       .values({
         id: data.email,
         email: data.email,
-        emailVerified: false,
         loginProvider: 'OTP',
         otp: code,
       })
@@ -69,7 +68,6 @@ export default defineEventHandler(async (event) => {
   await useDb()
     .update(users)
     .set({
-      emailVerified: true,
       otp: null, // Clear the OTP after successful login
       statementToken: user.statementToken || generate(20, { specialChars: false }), // and make sure the user has a statement token
     })
@@ -80,6 +78,13 @@ export default defineEventHandler(async (event) => {
       login: user.id,
     },
     loggedInAt: Date.now(),
+    loginProvider: 'OTP',
+    secure: {
+      name: user.name,
+      address: user.address,
+      identifierType: user.identifierType,
+      identifierValue: user.identifierValue,
+    },
   });
 
   return sendRedirect(event, '/account');

--- a/server/api/users/me.js
+++ b/server/api/users/me.js
@@ -1,5 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import { LOGIN_PROVIDED_FIELDS } from '~~/shared/utils/constants';
+import { editableUserDataFields, LOGIN_PROVIDED_FIELDS } from '~~/shared/utils/constants';
 import users from '~~/server/db/schema/users';
 
 export default defineEventHandler(async (event) => {
@@ -12,12 +12,15 @@ export default defineEventHandler(async (event) => {
   const db = useDb();
 
   const [user] = await db.select().from(users).where(eq(users.id, userId));
-  if (!user) {
-    throw createError({ status: 404, statusMessage: 'Not found' });
+
+  if (!session.secure) {
+    throw createError({ status: 500, statusMessage: 'User session is missing secure data' });
   }
 
   if (event.method === 'GET') {
     const query = getQuery(event);
+    /** @type {import('~~/server/db/schema/users.js').User|undefined} */
+    let onBehalfOfUserData = undefined;
     if (query.onBehalfOf && query.token) {
       const [onBehalfOfUser] = await db
         .select()
@@ -31,18 +34,69 @@ export default defineEventHandler(async (event) => {
       if (!onBehalfOfUser) {
         throw createError({ status: 404, statusMessage: 'Not found' });
       }
-      return { ...user, ...session.secure, onBehalfOf: onBehalfOfUser };
+      if (
+        !onBehalfOfUser.name ||
+        !onBehalfOfUser.address ||
+        !onBehalfOfUser.identifierType ||
+        !onBehalfOfUser.identifierValue
+      ) {
+        throw createError({
+          status: 400,
+          statusMessage: 'on-behalf-of user is missing required properties',
+        });
+      }
+      onBehalfOfUserData = {
+        id: onBehalfOfUser.id,
+        loginProvider: onBehalfOfUser.loginProvider,
+        name: onBehalfOfUser.name,
+        address: onBehalfOfUser.address,
+        identifierType: onBehalfOfUser.identifierType,
+        identifierValue: onBehalfOfUser.identifierValue,
+        email: onBehalfOfUser.email ?? null,
+        otp: null,
+        statementToken: null,
+      };
     }
-    return { ...user, ...session.secure };
+    return {
+      id: userId,
+      loginProvider: session.loginProvider,
+      name: session.secure.name,
+      address: session.secure.address,
+      identifierType: session.secure.identifierType,
+      identifierValue: session.secure.identifierValue,
+      email: user?.email ?? null,
+      otp: user?.otp ?? null,
+      statementToken: user?.statementToken ?? null,
+      onBehalfOf: onBehalfOfUserData,
+    };
   }
 
   if (event.method === 'PUT' && event.headers.get('content-type') === 'application/json') {
     /** @type {import('~~/server/db/schema/users.js').User} */
     const properties = await readBody(event);
-    const loginProvidedFields = LOGIN_PROVIDED_FIELDS[user.loginProvider];
+    const loginProvidedFields = LOGIN_PROVIDED_FIELDS[session.loginProvider];
+    await setUserSession(event, {
+      secure: {
+        ...session.secure,
+        name: properties.name,
+        address: properties.address,
+        identifierType: properties.identifierType,
+        identifierValue: properties.identifierValue,
+      },
+    });
     for (const property of loginProvidedFields) {
       // clear properties provided by login
       delete properties[property];
+    }
+    let noProperties = true;
+    for (const key of editableUserDataFields) {
+      if (key in properties) {
+        noProperties = false;
+        break;
+      }
+    }
+    if (noProperties) {
+      return;
     }
     await db
       .update(users)

--- a/server/db/migrations/0012_statements-author-not_null.sql
+++ b/server/db/migrations/0012_statements-author-not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "statements" ALTER COLUMN "author" SET NOT NULL;

--- a/server/db/migrations/0013_statements-change-fields-users-remove-emailVerified.sql
+++ b/server/db/migrations/0013_statements-change-fields-users-remove-emailVerified.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "statements" DROP CONSTRAINT "statements_ddsId_unique";--> statement-breakpoint
+ALTER TABLE "statements" DROP CONSTRAINT "statements_author_users_id_fk";
+--> statement-breakpoint
+ALTER TABLE "statements" DROP COLUMN "id";--> statement-breakpoint
+ALTER TABLE "statements" ADD PRIMARY KEY ("ddsId");--> statement-breakpoint
+ALTER TABLE "statements" ALTER COLUMN "ddsId" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "statements" ADD COLUMN "authorName" varchar(127) NOT NULL;--> statement-breakpoint
+ALTER TABLE "statements" ADD COLUMN "authorAddress" varchar(255) NOT NULL;--> statement-breakpoint
+ALTER TABLE "statements" DROP COLUMN "author";--> statement-breakpoint
+ALTER TABLE "users" DROP COLUMN "emailVerified";

--- a/server/db/migrations/meta/0012_snapshot.json
+++ b/server/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,233 @@
+{
+  "id": "72783b1f-b820-4636-8292-8550ccb29f67",
+  "prevId": "1ba1966b-3d92-41a5-9a2a-6ca538b03499",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_cattle": {
+      "name": "ama_cattle",
+      "schema": "",
+      "columns": {
+        "ddsId": {
+          "name": "ddsId",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ama_cattle_userId_users_id_fk": {
+          "name": "ama_cattle_userId_users_id_fk",
+          "tableFrom": "ama_cattle",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statements": {
+      "name": "statements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ddsId": {
+          "name": "ddsId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "statements_ddsId": {
+          "name": "statements_ddsId",
+          "columns": [
+            {
+              "expression": "ddsId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statements_userId_users_id_fk": {
+          "name": "statements_userId_users_id_fk",
+          "tableFrom": "statements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "statements_author_users_id_fk": {
+          "name": "statements_author_users_id_fk",
+          "tableFrom": "statements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "statements_ddsId_unique": {
+          "name": "statements_ddsId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ddsId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(127)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "identifierType": {
+          "name": "identifierType",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifierValue": {
+          "name": "identifierValue",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loginProvider": {
+          "name": "loginProvider",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otp": {
+          "name": "otp",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statementToken": {
+          "name": "statementToken",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/0013_snapshot.json
+++ b/server/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,204 @@
+{
+  "id": "70781e97-1372-4b13-8a8c-f45f24b3fecd",
+  "prevId": "72783b1f-b820-4636-8292-8550ccb29f67",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ama_cattle": {
+      "name": "ama_cattle",
+      "schema": "",
+      "columns": {
+        "ddsId": {
+          "name": "ddsId",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ama_cattle_userId_users_id_fk": {
+          "name": "ama_cattle_userId_users_id_fk",
+          "tableFrom": "ama_cattle",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statements": {
+      "name": "statements",
+      "schema": "",
+      "columns": {
+        "ddsId": {
+          "name": "ddsId",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorName": {
+          "name": "authorName",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorAddress": {
+          "name": "authorAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "statements_ddsId": {
+          "name": "statements_ddsId",
+          "columns": [
+            {
+              "expression": "ddsId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "statements_userId_users_id_fk": {
+          "name": "statements_userId_users_id_fk",
+          "tableFrom": "statements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(127)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(127)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifierType": {
+          "name": "identifierType",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifierValue": {
+          "name": "identifierValue",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loginProvider": {
+          "name": "loginProvider",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otp": {
+          "name": "otp",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statementToken": {
+          "name": "statementToken",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -85,6 +85,20 @@
       "when": 1756409136644,
       "tag": "0011_ama_cattle-create",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1758899352448,
+      "tag": "0012_statements-author-not_null",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1758923446105,
+      "tag": "0013_statements-change-fields-users-remove-emailVerified",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/statements.js
+++ b/server/db/schema/statements.js
@@ -1,15 +1,16 @@
 import { pgTable, timestamp, uniqueIndex, uuid, varchar } from 'drizzle-orm/pg-core';
 import users from './users';
 
+// Table for statements created on behalf of another user
 const statements = pgTable(
   'statements',
   {
-    id: uuid().primaryKey().defaultRandom(),
+    ddsId: uuid().primaryKey(),
     userId: varchar({ length: 127 })
       .notNull()
       .references(() => users.id),
-    author: varchar({ length: 127 }).references(() => users.id),
-    ddsId: uuid().unique(),
+    authorName: varchar({ length: 127 }).notNull(),
+    authorAddress: varchar({ length: 255 }).notNull(),
     date: timestamp().notNull(),
   },
   (table) => [uniqueIndex('statements_ddsId').on(table.ddsId)],

--- a/server/db/schema/users.js
+++ b/server/db/schema/users.js
@@ -1,11 +1,10 @@
-import { boolean, numeric, pgTable, varchar } from 'drizzle-orm/pg-core';
+import { numeric, pgTable, varchar } from 'drizzle-orm/pg-core';
 
 const users = pgTable('users', {
   id: varchar({ length: 127 }).primaryKey(),
   name: varchar({ length: 127 }),
   address: varchar({ length: 255 }),
   email: varchar({ length: 127 }),
-  emailVerified: boolean().default(false).notNull(),
   identifierType: varchar({ enum: ['GLN', 'TIN', 'VAT'], length: 3 }),
   identifierValue: varchar({ length: 15 }),
   loginProvider: varchar({ enum: ['AMA', 'IDA', 'USP', 'OTP'], length: 3 }).notNull(),

--- a/server/routes/auth/usp.get.js
+++ b/server/routes/auth/usp.get.js
@@ -21,23 +21,16 @@ export default defineOAuthUSPEventHandler({
       .insert(users)
       .values({
         id: user.login,
-        emailVerified: false,
         loginProvider: 'USP',
       })
-      //TODO remove - this only deletes legacy data
-      .onConflictDoUpdate({
-        target: users.id,
-        set: {
-          name: null,
-          address: null,
-        },
-      });
+      .onConflictDoNothing();
 
     await setUserSession(event, {
       user: {
         login: user.login,
       },
-      secure: { name, address },
+      loginProvider: 'USP',
+      secure: { name, address, identifierType: 'GLN', identifierValue: user.identifierValue },
       loggedInAt: Date.now(),
     });
 

--- a/server/tasks/ama-cattle.js
+++ b/server/tasks/ama-cattle.js
@@ -43,7 +43,7 @@ export default defineTask({
               referenzNummer: dds.referenceNumber,
               verifikationsNummer: dds.verificationNumber,
               stueckZahl: entry.count,
-              datumVon: dds.date.toISOString(),
+              datumVon: new Date(dds.date).toISOString(),
             },
             null,
             2,

--- a/shared/auth.d.ts
+++ b/shared/auth.d.ts
@@ -1,4 +1,5 @@
 import type { CommodityDataWithKey } from '../server/utils/soap-traces';
+import type { LoginProvider } from './utils/constants';
 
 declare module '#auth-utils' {
   interface User {
@@ -7,6 +8,7 @@ declare module '#auth-utils' {
 
   interface UserSession {
     loggedInAt: number;
+    loginProvider: LoginProvider;
     commodities: Record<string, Array<CommodityDataWithKey>>;
   }
 

--- a/shared/utils/constants.js
+++ b/shared/utils/constants.js
@@ -62,11 +62,13 @@ export const COMMODITY_KEYS = /** @type {Array<Commodity>} */ (Object.keys(COMMO
 
 /** @type {Record<LoginProvider, Array<keyof import('~~/server/db/schema/users.js').User>>} */
 export const LOGIN_PROVIDED_FIELDS = {
-  OTP: ['email'],
+  OTP: [],
   IDA: ['name', 'address'],
   AMA: ['name', 'address', 'identifierType', 'identifierValue'],
   USP: ['name', 'address', 'identifierType', 'identifierValue'],
 };
+
+export const editableUserDataFields = ['name', 'address', 'identifierType', 'identifierValue'];
 
 const VALID_EMAIL_REGEX =
   /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;


### PR DESCRIPTION
Except for on-behalf-of statements, it is not necessary to create an entry in the `statements` table. For better transparency, we now store name and address of a user who creates a statement on behalf of another user. The privacy statement has been updated accordingly.

We no longer create an entry in the 'users' table when the login provider supplies all of `name`, `address`, `identifierType` and `identifierValue`. The privacy statement has been updated to reflect this.

Since we did not use the user's e-mail except for E-mail login to send a OTP, I removed the `e-mail` field from the user form.