### PR TITLE
Quantities help and postal address guidance/checkbox

### DIFF
--- a/app/components/GeolocationsDialog.client.vue
+++ b/app/components/GeolocationsDialog.client.vue
@@ -5,11 +5,26 @@ import Map from 'ol/Map.js';
 import 'ol/ol.css';
 import VectorSource from 'ol/source/Vector.js';
 import { View } from 'ol';
+import { fromLonLat, transformExtent } from 'ol/proj';
+
+/** Fallback extent (Austria) used when there is no geolocation to fit to. */
+const austriaExtent = [...fromLonLat([9.530952, 46.372276]), ...fromLonLat([17.160776, 49.020608])];
 
 const props = defineProps({
   geojson: {
     type: /** @type {import('vue').PropType<import('geojson').FeatureCollection<import('geojson').Geometry|null>>} */ (
       Object
+    ),
+    default: null,
+  },
+  /**
+   * Fallback extent (`[minX, minY, maxX, maxY]` in EPSG:4326) used to fit the
+   * map when `geojson` has no features, e.g. a precomputed bounding box for
+   * a set of fields. Ignored once `geojson` provides an extent of its own.
+   */
+  extent: {
+    type: /** @type {import('vue').PropType<[number, number, number, number]>} */ (
+      /** @type {unknown} */ (Array)
     ),
     default: null,
   },
@@ -27,6 +42,7 @@ const mapContainer = ref(null);
 
 const fields = (await useFetch('/api/lfbis?layer=fields')).data.value;
 const farms = (await useFetch('/api/lfbis?layer=farms')).data.value;
+const fieldsExtent = (await useFetch('/api/lfbis-extent')).data.value;
 
 const geojsonFormat = new GeoJSON({ featureProjection: 'EPSG:3857' });
 const geolocationSource = new VectorSource();
@@ -74,9 +90,18 @@ async function fitMap() {
   if (mapContainer.value) {
     map.setTarget(mapContainer.value);
     map.updateSize();
-    const extent = geolocationSource.getExtent();
-    if (extent && Number.isFinite(extent[0])) {
-      map.getView().fit(extent, { padding: [20, 20, 20, 20], maxZoom: 18 });
+    const geojsonExtent = geolocationSource.getExtent();
+    const hasGeojsonExtent = geojsonExtent && Number.isFinite(geojsonExtent[0]);
+    const fallbackExtent = props.extent ?? fieldsExtent;
+    if (hasGeojsonExtent) {
+      map.getView().fit(geojsonExtent, { padding: [20, 20, 20, 20], maxZoom: 18 });
+    } else if (fallbackExtent) {
+      map.getView().fit(transformExtent(fallbackExtent, 'EPSG:4326', 'EPSG:3857'), {
+        padding: [20, 20, 20, 20],
+        maxZoom: 16,
+      });
+    } else {
+      map.getView().fit(austriaExtent, { padding: [20, 20, 20, 20], maxZoom: 10 });
     }
   }
 }

--- a/app/components/PlacesForm.vue
+++ b/app/components/PlacesForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { mdiHelpCircleOutline } from '@mdi/js';
+import { mdiEyeOutline, mdiHelpCircleOutline } from '@mdi/js';
 
 const props = defineProps({
   commodity: {
@@ -8,12 +8,19 @@ const props = defineProps({
     ),
     required: true,
   },
+  isAma: Boolean,
 });
 
 const { xs } = useDisplay();
-const { geojson, quantity, address, geolocation } = useStatement(props.commodity);
+const { geojson, quantity, address, geolocation } = useStatement(props.commodity, props.isAma);
+
+/** Soja producers with an AMA login register their fields via MFA, so they get
+ * the "confirm all fields are in AMA/MFA" checkbox and the map preview button. */
+const isAmaSoja = computed(() => props.isAma && props.commodity === 'sojabohnen');
 
 const form = ref();
+const mfaConfirmed = ref(false);
+const showFieldsMap = ref(false);
 
 /**
  * Validate the visible fields (the postal address is required when "Postadresse"
@@ -130,6 +137,43 @@ watch(yieldPerHectare, (value) => {
       </v-row>
       <v-row v-if="!geolocation && address" no-gutters class="mt-8">
         <v-col cols="12" lg="6">
+          <v-checkbox
+            v-if="isAmaSoja"
+            v-model="mfaConfirmed"
+            density="compact"
+            hide-details="auto"
+            class="mb-4"
+            :rules="[(v) => !!v || 'Bitte bestätigen Sie diese Angabe']"
+          >
+            <template #label>
+              <div class="ml-1 text-body-2">
+                Sämtliche meiner Flächen sind im System der AMA mittels MFA hinterlegt.
+              </div>
+              <v-tooltip max-width="400" open-on-click>
+                <template #activator="{ props: activatorProps }">
+                  <v-btn
+                    flat
+                    :icon="mdiHelpCircleOutline"
+                    size="x-small"
+                    v-bind="activatorProps"
+                  ></v-btn>
+                </template>
+                <div>
+                  Wenn nicht alle Flächen gewünscht sind, bitte über Geolokalisation die korrekten
+                  Flächen wählen.
+                </div>
+              </v-tooltip>
+            </template>
+          </v-checkbox>
+          <v-btn
+            v-if="isAmaSoja"
+            class="mb-6"
+            variant="outlined"
+            :prepend-icon="mdiEyeOutline"
+            @click="showFieldsMap = true"
+          >
+            Flächen anzeigen
+          </v-btn>
           <div class="text-subtitle-2 mb-4">Postadresse des Erzeugungsorts</div>
           <v-row>
             <v-col cols="12">
@@ -166,6 +210,8 @@ watch(yieldPerHectare, (value) => {
       </v-row>
     </v-form>
   </v-container>
+
+  <geolocations-dialog v-model="showFieldsMap" :commodity="props.commodity" />
 </template>
 
 <style scoped>

--- a/app/components/PlacesForm.vue
+++ b/app/components/PlacesForm.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { mdiHelpCircleOutline } from '@mdi/js';
+
 const props = defineProps({
   commodity: {
     type: /** @type {import('vue').PropType<import('~~/shared/utils/constants.js').Commodity>} */ (
@@ -82,17 +84,19 @@ watch(yieldPerHectare, (value) => {
             :label="HS_HEADING[hs]"
             :suffix="COMMODITIES[commodity]?.units"
           ></v-text-field>
-          <v-text-field
-            v-if="yieldPerHectare !== undefined"
-            v-model.number="yieldPerHectare"
-            class="yield-field"
-            label="Ertrag/ha"
-            :suffix="COMMODITIES[commodity]?.units"
-            density="compact"
-            variant="plain"
-            type="number"
-            hide-details
-          ></v-text-field>
+          <v-tooltip v-if="commodityData.hint" max-width="300" open-on-click location="top" pa-0>
+            <template #activator="{ props: activatorProps }">
+              <v-btn
+                class="flex-grow-0 flex-shrink-0"
+                :class="xs ? 'ms-n2' : 'ms-n4'"
+                flat
+                :icon="mdiHelpCircleOutline"
+                size="x-small"
+                v-bind="activatorProps"
+              ></v-btn>
+            </template>
+            <div>{{ commodityData.hint }}</div>
+          </v-tooltip>
           <v-select
             v-model="geolocation"
             class="select-field"
@@ -105,6 +109,17 @@ watch(yieldPerHectare, (value) => {
             variant="outlined"
             hide-details
           />
+          <v-text-field
+            v-if="geolocation && yieldPerHectare !== undefined"
+            v-model.number="yieldPerHectare"
+            class="yield-field"
+            label="Ertrag/ha"
+            :suffix="COMMODITIES[commodity]?.units"
+            density="compact"
+            variant="plain"
+            type="number"
+            hide-details
+          ></v-text-field>
           <v-sheet v-if="geolocation" class="stats text-no-wrap text-caption">
             {{ geojson.features.length }} Ort{{ geojson.features.length === 1 ? '' : 'e' }}<br />{{
               area.toLocaleString('de-AT')
@@ -154,25 +169,26 @@ watch(yieldPerHectare, (value) => {
 </template>
 
 <style scoped>
-/* Quantity inputs share the leftover width evenly and are allowed to shrink
-   below their intrinsic size (min-width: 0) so the row never wraps, but keep a
-   floor wide enough to show their label. */
+/* Quantity inputs keep a comfortable width instead of growing to fill the
+   row, and are allowed to shrink below their intrinsic size so the row never
+   wraps, but keep a floor wide enough to show their label. */
 .quantity-field {
-  flex: 1 1 0;
+  flex: 0 1 140px;
   min-width: 110px;
 }
 
-/* The select needs to stay readable, so give it more of the free space and a
-   larger floor than the quantity fields. */
+/* The select doesn't need to grow with the row; keep it at a comfortable
+   reading width so it doesn't consume the entire remaining space on large
+   screens, while still able to shrink on narrow ones. */
 .select-field {
-  flex: 2 1 0;
+  flex: 0 1 220px;
   min-width: 150px;
 }
 
 /* The yield field is auxiliary; keep it narrow and non-growing. */
 .yield-field {
   flex: 0 0 auto;
-  width: 80px;
+  width: 60px;
 }
 
 /* Statistics keep their natural size; the flexible fields absorb the rest. */
@@ -185,15 +201,15 @@ watch(yieldPerHectare, (value) => {
    whole line — statistics included — still fits. */
 @media (max-width: 480px) {
   .quantity-field {
-    min-width: 64px;
+    min-width: 56px;
   }
 
   .select-field {
-    min-width: 96px;
+    min-width: 88px;
   }
 
   .yield-field {
-    width: 60px;
+    width: 56px;
   }
 }
 </style>

--- a/app/composables/useStatement.js
+++ b/app/composables/useStatement.js
@@ -75,19 +75,23 @@ function restoreSnapshot(snapshot, quantity, geojson, address, geolocation) {
  * @param {Ref<import('geojson').FeatureCollection>} geojson
  * @param {Ref<Address>} address
  * @param {Ref<boolean>} geolocation
+ * @param {boolean} defaultGeolocation
  */
-function clear(quantity, geojson, address, geolocation) {
+function clear(quantity, geojson, address, geolocation, defaultGeolocation) {
   quantity.value = {};
   geojson.value = structuredClone(EMPTY_GEOJSON);
   address.value = null;
-  geolocation.value = false;
+  geolocation.value = defaultGeolocation;
 }
 
 /**
  * @param {import('~~/shared/utils/constants').Commodity} commodity
+ * @param {boolean} [isAma] Whether the logged in user has an AMA (eAMA) login.
  * @returns {UseStatement}
  */
-export function useStatement(commodity) {
+export function useStatement(commodity, isAma = false) {
+  const defaultGeolocation = !(isAma && commodity === 'sojabohnen');
+
   /** @type {import('vue').Ref<import('ol/format/GeoJSON').GeoJSONFeatureCollection>} */
   const geojson = useState(`geojson-${commodity}`, () =>
     shallowRef(structuredClone(EMPTY_GEOJSON)),
@@ -105,7 +109,7 @@ export function useStatement(commodity) {
    * false). Governs which of the two is submitted to TRACES.
    * @type {import('vue').Ref<boolean>}
    */
-  const geolocation = useState(`geolocation-${commodity}`, () => false);
+  const geolocation = useState(`geolocation-${commodity}`, () => defaultGeolocation);
 
   /** @type {Snapshot} */
   const snapshot = useState(`snapshot-${commodity}`, () => null);
@@ -140,6 +144,6 @@ export function useStatement(commodity) {
     modifiedSinceSnapshot,
     createSnapshot: () => createSnapshot(snapshot, quantity, geojson, address, geolocation),
     restoreSnapshot: () => restoreSnapshot(snapshot, quantity, geojson, address, geolocation),
-    clear: () => clear(quantity, geojson, address, geolocation),
+    clear: () => clear(quantity, geojson, address, geolocation, defaultGeolocation),
   };
 }

--- a/app/pages/statement.vue
+++ b/app/pages/statement.vue
@@ -68,6 +68,13 @@ const savedOnBehalfOf = ref(false);
 /** @type {import('vue').Ref<boolean>} */
 const confirm = ref(false);
 
+const isAma = computed(() => {
+  const loginProvider = onBehalfOfUser?.value
+    ? onBehalfOfUser.value.loginProvider
+    : user.value?.loginProvider;
+  return loginProvider === 'AMA';
+});
+
 /**
  * Per-commodity statement state, created once here rather than by re-invoking
  * `useStatement()` inside computeds and handlers. The composable registers a
@@ -76,7 +83,7 @@ const confirm = ref(false);
  */
 const statements =
   /** @type {Record<import('~~/shared/utils/constants').Commodity, ReturnType<typeof useStatement>>} */ (
-    Object.fromEntries(COMMODITY_KEYS.map((key) => [key, useStatement(key)]))
+    Object.fromEntries(COMMODITY_KEYS.map((key) => [key, useStatement(key, isAma.value)]))
   );
 
 /**
@@ -279,7 +286,7 @@ async function validate() {
 
         <v-btn :icon="mdiCheck" :commodity="editCommodity" @click="validate"></v-btn>
       </v-toolbar>
-      <places-form ref="placesFormRef" :commodity="editCommodity" />
+      <places-form ref="placesFormRef" :commodity="editCommodity" :is-ama="isAma" />
       <places-map
         v-if="showMapEditor"
         style="flex: 1 1 0; min-height: 0"
@@ -321,12 +328,7 @@ async function validate() {
                 <CommodityCard :item="item" @open-editor="openEditor" />
               </v-col>
             </v-row>
-            <v-checkbox
-              v-model="geolocationVisible"
-              class="mt-4 checkbox-align-start"
-              hide-details
-              density="compact"
-            >
+            <v-checkbox v-model="geolocationVisible" class="mt-4" hide-details density="compact">
               <template #label>
                 <div class="ml-1 text-body-2">
                   Erzeugungsorte für nachfolgende Marktteilnehmer freigeben

--- a/app/utils/layers-sources.client.js
+++ b/app/utils/layers-sources.client.js
@@ -29,6 +29,18 @@ export function createBackgroundKatasterLayer() {
 }
 
 /**
+ * Mapbox GL expression that's true for schläge belonging to the given commodity.
+ * @param {import('~~/shared/utils/constants').Commodity} commodity
+ * @returns {Array<*>}
+ */
+function commodityMatchExpression(commodity) {
+  if (commodity === 'sojabohnen') {
+    return ['==', ['get', 'fnar'], 'A'];
+  }
+  return ['in', SNAR_SUBSTRING[commodity], ['get', 'snar_bezeichnung']];
+}
+
+/**
  * @param {import('~~/shared/utils/constants').Commodity} commodity
  * @param {Array<string>} [farms]
  * @param {Array<string>} [fields]
@@ -53,7 +65,7 @@ function createAgraratlasLayer(commodity, farms = [], fields = []) {
         filter: [
           'all',
           ['!', ['in', ['get', 'localID'], ['literal', fields]]],
-          ['!', ['in', SNAR_SUBSTRING[commodity], ['get', 'snar_bezeichnung']]],
+          ['!', commodityMatchExpression(commodity)],
         ],
       },
       'invekos_schlaege_polygon-fill',
@@ -66,7 +78,7 @@ function createAgraratlasLayer(commodity, farms = [], fields = []) {
         filter: [
           'all',
           ['in', ['get', 'localID'], ['literal', fields]],
-          ['!', ['in', SNAR_SUBSTRING[commodity], ['get', 'snar_bezeichnung']]],
+          ['!', commodityMatchExpression(commodity)],
         ],
         paint: {
           ...schlaege.paint,
@@ -83,7 +95,7 @@ function createAgraratlasLayer(commodity, farms = [], fields = []) {
         filter: [
           'all',
           ['!', ['in', ['get', 'localID'], ['literal', fields]]],
-          ['in', SNAR_SUBSTRING[commodity], ['get', 'snar_bezeichnung']],
+          commodityMatchExpression(commodity),
         ],
         paint: {
           ...schlaege.paint,
@@ -100,7 +112,7 @@ function createAgraratlasLayer(commodity, farms = [], fields = []) {
         filter: [
           'all',
           ['in', ['get', 'localID'], ['literal', fields]],
-          ['in', SNAR_SUBSTRING[commodity], ['get', 'snar_bezeichnung']],
+          commodityMatchExpression(commodity),
         ],
         paint: {
           ...schlaege.paint,

--- a/server/api/lfbis-extent.get.js
+++ b/server/api/lfbis-extent.get.js
@@ -1,0 +1,20 @@
+import { eq } from 'drizzle-orm';
+import lfbisField from '~~/server/db/schema/lfbis_field';
+
+export default defineEventHandler(async (event) => {
+  const session = await requireUserSession(event);
+  if (!session?.user?.login) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+  }
+  if (session.loginProvider !== 'AMA') {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' });
+  }
+
+  const db = useDb();
+  const localIds = await db
+    .select({ localId: lfbisField.localId })
+    .from(lfbisField)
+    .where(eq(lfbisField.lfbis, session.user.login));
+
+  return getExtentForLocalIds(localIds.map((r) => r.localId));
+});

--- a/server/api/lfbis.get.js
+++ b/server/api/lfbis.get.js
@@ -8,7 +8,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
   }
   if (session.loginProvider !== 'AMA') {
-    //throw createError({ statusCode: 403, statusMessage: 'Forbidden' });
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' });
   }
 
   const query = getQuery(event);

--- a/server/plugins/schlaege-index.js
+++ b/server/plugins/schlaege-index.js
@@ -1,0 +1,3 @@
+export default defineNitroPlugin(() => {
+  warmSchlaegeIndex();
+});

--- a/server/utils/schlaege-index.js
+++ b/server/utils/schlaege-index.js
@@ -1,0 +1,194 @@
+const INDEX_URL = 'https://assets.w3geo.at/agraratlas/map/tiles/invekos_schlaege_polygon.index.bin';
+
+/** Floor for how long the index is considered fresh, in case a response is ever
+ * missing a parseable `Cache-Control: max-age` (this CDN always sends one today). */
+const MIN_MAX_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * @typedef {Object} SchlaegeIndex
+ * @property {Uint32Array} ids Schlag localIds, sorted ascending.
+ * @property {Float32Array} extents `[minX, minY, maxX, maxY]` (EPSG:4326) per id, four
+ *   entries per index position, same order as `ids`.
+ */
+
+/** @type {SchlaegeIndex|undefined} */
+let index;
+/** @type {string|undefined} */
+let indexEtag;
+let indexLoadedAt = 0;
+let indexMaxAgeMs = MIN_MAX_AGE_MS;
+/** @type {Promise<SchlaegeIndex>|undefined} */
+let indexPromise;
+
+/**
+ * @param {string|null} cacheControl
+ * @returns {number} The parsed `max-age` in ms, clamped to `MIN_MAX_AGE_MS`, or
+ *   `MIN_MAX_AGE_MS` itself if `cacheControl` has no parseable `max-age`.
+ */
+function resolveMaxAgeMs(cacheControl) {
+  const match = cacheControl?.match(/max-age=(\d+)/);
+  const maxAgeMs = match ? Number(match[1]) * 1000 : undefined;
+  return Math.max(maxAgeMs ?? MIN_MAX_AGE_MS, MIN_MAX_AGE_MS);
+}
+
+/**
+ * Wraps a response body in typed-array views directly over the buffer — no
+ * parsing, no copying.
+ * @param {Response} response
+ * @returns {Promise<SchlaegeIndex>}
+ */
+async function parseIndex(response) {
+  const buffer = await response.arrayBuffer();
+  const count = new Uint32Array(buffer, 0, 1)[0] ?? 0;
+  const ids = new Uint32Array(buffer, 4, count);
+  const extents = new Float32Array(buffer, 4 + count * 4, count * 4);
+  return { ids, extents };
+}
+
+/**
+ * Downloads a fresh copy of the ~58 MB invekos_schlaege spatial index
+ * (localId -> extent), a little-endian binary blob of `[count: uint32,
+ * localIds: uint32[count] sorted ascending, bboxes: float32[count * 4]]`.
+ * @returns {Promise<{ data: SchlaegeIndex, etag: string|undefined, maxAgeMs: number }>}
+ */
+async function fetchFullIndex() {
+  const response = await fetch(INDEX_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch schlaege index: ${response.status} ${response.statusText}`);
+  }
+  const etag = response.headers.get('etag') ?? undefined;
+  const maxAgeMs = resolveMaxAgeMs(response.headers.get('cache-control'));
+  const data = await parseIndex(response);
+  return { data, etag, maxAgeMs };
+}
+
+/**
+ * Loads the index for the first time, or revalidates the cached one against
+ * `INDEX_URL` using `If-None-Match`, so an unchanged file costs a cheap 304
+ * instead of a fresh ~58 MB download. Falls back to serving the stale index
+ * (if any) when a revalidation attempt itself fails.
+ * @returns {Promise<SchlaegeIndex>}
+ */
+async function refreshIndex() {
+  if (!index || !indexEtag) {
+    const full = await fetchFullIndex();
+    index = full.data;
+    indexEtag = full.etag;
+    indexMaxAgeMs = full.maxAgeMs;
+    indexLoadedAt = Date.now();
+    return index;
+  }
+
+  try {
+    const response = await fetch(INDEX_URL, { headers: { 'If-None-Match': indexEtag } });
+    if (response.status === 304) {
+      indexMaxAgeMs = resolveMaxAgeMs(response.headers.get('cache-control'));
+      indexLoadedAt = Date.now();
+      return index;
+    }
+    if (!response.ok) {
+      indexLoadedAt = Date.now();
+      return index;
+    }
+    index = await parseIndex(response);
+    indexEtag = response.headers.get('etag') ?? undefined;
+    indexMaxAgeMs = resolveMaxAgeMs(response.headers.get('cache-control'));
+    indexLoadedAt = Date.now();
+    return index;
+  } catch {
+    indexLoadedAt = Date.now();
+    return index;
+  }
+}
+
+/**
+ * Returns the cached index, loading or revalidating it as needed per the
+ * server's `Cache-Control: max-age` and `ETag`. Concurrent callers share the
+ * same in-flight fetch.
+ * @returns {Promise<SchlaegeIndex>}
+ */
+function getIndex() {
+  if (index && Date.now() - indexLoadedAt < indexMaxAgeMs) {
+    return Promise.resolve(index);
+  }
+  if (!indexPromise) {
+    indexPromise = refreshIndex().finally(() => {
+      indexPromise = undefined;
+    });
+  }
+  return indexPromise;
+}
+
+/**
+ * @param {Uint32Array} ids Sorted ascending.
+ * @param {number} id
+ * @returns {number} Index of `id` in `ids`, or -1 if not found.
+ */
+function binarySearch(ids, id) {
+  let lo = 0;
+  let hi = ids.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const value = ids[mid];
+    if (value === undefined) {
+      return -1;
+    }
+    if (value === id) {
+      return mid;
+    }
+    if (value < id) {
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Combines the extents of the given schlag localIds into a single bounding
+ * box, using the cached spatial index (never re-downloaded per call).
+ * @param {Array<string|number>} localIds
+ * @returns {Promise<[number, number, number, number]|null>} `[minX, minY, maxX, maxY]`
+ *   in EPSG:4326, or `null` if `localIds` is empty or none were found.
+ */
+export async function getExtentForLocalIds(localIds) {
+  if (!localIds.length) {
+    return null;
+  }
+  const { ids, extents } = await getIndex();
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let found = false;
+  for (const localId of localIds) {
+    const i = binarySearch(ids, Number(localId));
+    if (i === -1) {
+      continue;
+    }
+    const o = i * 4;
+    const x0 = extents[o];
+    const y0 = extents[o + 1];
+    const x1 = extents[o + 2];
+    const y1 = extents[o + 3];
+    if (x0 === undefined || y0 === undefined || x1 === undefined || y1 === undefined) {
+      continue;
+    }
+    found = true;
+    if (x0 < minX) minX = x0;
+    if (y0 < minY) minY = y0;
+    if (x1 > maxX) maxX = x1;
+    if (y1 > maxY) maxY = y1;
+  }
+  return found ? [minX, minY, maxX, maxY] : null;
+}
+
+/**
+ * Kicks off (or reuses) the index load without waiting for it, so the first
+ * real request doesn't have to pay for the download.
+ */
+export function warmSchlaegeIndex() {
+  getIndex().catch(() => {});
+}

--- a/shared/utils/constants.js
+++ b/shared/utils/constants.js
@@ -49,7 +49,6 @@ export const COMMODITIES = {
 
 /** @type {Object<string, string>} */
 export const SNAR_SUBSTRING = {
-  sojabohnen: 'SOJABOHNEN',
   rind: 'WEIDE',
   reinrassigesZuchtrind: 'WEIDE',
 };

--- a/shared/utils/constants.js
+++ b/shared/utils/constants.js
@@ -9,6 +9,7 @@ import { mdiCow, mdiForestOutline, mdiSprout } from '@mdi/js';
  * @property {'t' | 'Stk.' | 'm³'} units
  * @property {number} [yieldPerHectare]
  * @property {Array<HSCode>} hsHeadings
+ * @property {string} [hint]
  */
 
 export const HS_HEADING = {
@@ -29,6 +30,7 @@ export const COMMODITIES = {
     units: 't',
     yieldPerHectare: 4,
     hsHeadings: ['1201'],
+    hint: 'Bitte geben Sie hier Ihre durchschnittliche jährliche Sojaproduktion an',
   },
   rind: {
     title: 'Rinder',
@@ -41,6 +43,7 @@ export const COMMODITIES = {
     icon: mdiForestOutline,
     units: 'm³',
     hsHeadings: ['4403', '4401'],
+    hint: 'Bitte geben Sie hier Ihre durchschnittliche jährliche Holzproduktion an',
   },
 };
 


### PR DESCRIPTION
The quantities fields for soy and wood now have a help button, to explain what users need to enter as quantity.

For eAMA users, the postal address form for soy now has a confirmation box to confirm that all MFA fields are used for soy, and a "Flächen anzeigen" button to verify that.

For soy, all Ackerland fields are now highlighted, instead of just those where the SNAR string contains "SOJABOHNEN".